### PR TITLE
remove dependency on time crate and use std::time::Instant instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,3 @@ license = "MIT"
 [lib]
 name = "timeit"
 doctest = false
-
-[dependencies]
-time = "0.1.26"


### PR DESCRIPTION
similar to the other PR but uses the more modern `Duration::as_secs_f64` and adds a test